### PR TITLE
Resolve #3 and #13

### DIFF
--- a/src/components/DrawGraphNetwork.js
+++ b/src/components/DrawGraphNetwork.js
@@ -164,15 +164,8 @@ function DrawGraphNetwork(props) {
       lastSelectedNodeId.current = nodeId;
     });
 
-    // ノードが変更されたときのイベントリスナー
-    nodes.on("*", () => {
-      const newNodes = [];
-      nodes.get().map(node => newNodes.push(node.label));
-      props.setNodesData(newNodes);
-    });
-
-    // エッジが変更されたときのイベントリスナー
-    edges.on("*", () => {
+    // エッジを更新する関数
+    const updateEdge = () => {
       const newEdges = [];
       console.log(nodes);
       console.log(edges);
@@ -183,6 +176,20 @@ function DrawGraphNetwork(props) {
         newEdges.push([fromLabel, toLabel]);
       });
       props.setEdgesData(newEdges);
+    }; 
+
+    // ノードが変更されたときのイベントリスナー
+    nodes.on("*", () => {
+      const newNodes = [];
+      nodes.get().map(node => newNodes.push(node.label));
+      props.setNodesData(newNodes);
+      // ノードの変更に追従してエッジも更新
+      updateEdge();
+    });
+
+    // エッジが変更されたときのイベントリスナー
+    edges.on("*", () => {
+      updateEdge();
     });
 
     const handleResize = () => {

--- a/src/components/GraphNetworkTextarea.js
+++ b/src/components/GraphNetworkTextarea.js
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { Button } from 'react-bootstrap';
 import CopyButton from "./CopyButton";
+import styles from "./GraphNetworkTextarea.module.css";
 
 function GraphNetworkTextarea(props) {
   const [textareaValue, setTextareaValue] = useState("");
@@ -58,11 +59,10 @@ function GraphNetworkTextarea(props) {
   return (
     <>
       <div className="my-1 position-relative">
-        <textarea className="form-control"
+        <textarea className={styles["form-control"]}
           value={textareaValue}
           onChange={handleTextareaChange}
           onKeyDown={handleKeyPress} // Ctrl+Enterを押したときの処理を追加
-          style={{ width: '100%', height: '300px' }}
         />
         <CopyButton text={textareaValue}/>
       </div>

--- a/src/components/GraphNetworkTextarea.js
+++ b/src/components/GraphNetworkTextarea.js
@@ -59,7 +59,7 @@ function GraphNetworkTextarea(props) {
   return (
     <>
       <div className="my-1 position-relative">
-        <textarea className={styles["form-control"]}
+        <textarea className={"form-control " + styles["form-control"]}
           value={textareaValue}
           onChange={handleTextareaChange}
           onKeyDown={handleKeyPress} // Ctrl+Enterを押したときの処理を追加

--- a/src/components/GraphNetworkTextarea.module.css
+++ b/src/components/GraphNetworkTextarea.module.css
@@ -1,0 +1,8 @@
+.form-control {
+    width: 100%;
+    height: 300px;
+}
+
+.form-control::first-line {
+    color: red;
+}


### PR DESCRIPTION
#3 
cssを別ファイルにして、疑似要素のfirst-lineを適用しました。
styled-componentsを使うと、テキストエリアに文字列を入力するたびにラグが生じたため、css-in-jsは見送りました。

#13 
頂点を更新時に、変更後の辺データが渡っていませんでした。